### PR TITLE
Create Instructure_Canvas_Note

### DIFF
--- a/SecureIdeas/Instructure_Canvas_Note
+++ b/SecureIdeas/Instructure_Canvas_Note
@@ -1,0 +1,1 @@
+This report is not a complete pent-test report from Secure Ideas. It is a simplified & sanitized summary prepared for Instructure to provide publicly to clients.


### PR DESCRIPTION
This note provides context around the provided report. There's nothing wrong with the report for what it is, but it's not a Secure Ideas pentest report as is suggested.